### PR TITLE
Add option to disable proxy check.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from distutils.core import setup
 from distutils.command.bdist_rpm import bdist_rpm as _bdist_rpm
 
 pkg_name = 'nagios-plugins-cream.cream-service'
-pkg_version = '1.2.2'
+pkg_version = '1.2.3'
 pkg_release = '1'
 pkg_ns = 'eu.egi.CREAMCE'
 

--- a/src/cream_cli/cream.py
+++ b/src/cream_cli/cream.py
@@ -39,6 +39,7 @@ class Client(object):
     DEFAULT_PORT = 8443
     DEFAULT_TIMEOUT = 120
     DEFAULT_VERBOSITY = False 
+    DEFAULT_DISABLE_PROXY_CHECK = False
 
     # Variables
     usage = "usage %prog [options]"
@@ -56,6 +57,7 @@ class Client(object):
     timeout = DEFAULT_TIMEOUT
     verbose = DEFAULT_VERBOSITY
     fullOptional = None
+    disableProxyCheck = DEFAULT_DISABLE_PROXY_CHECK
 
 
     def __init__(self, name, version):
@@ -104,6 +106,12 @@ class Client(object):
                       dest="verbose",
                       help="verbose mode [default: %default]",
                       default = self.DEFAULT_VERBOSITY)
+
+        optionParser.add_option("--disable-proxy-check",
+                      action="store_true",
+                      dest="disableProxyCheck",
+                      help="Disable checking user proxy certificate validity [default: %default]",
+                      default = self.DEFAULT_DISABLE_PROXY_CHECK)
  
         if fullOptional == "TRUE":
             optionParser.add_option("-u",
@@ -198,6 +206,9 @@ class Client(object):
         if self.options.verbose:
             self.verbose = self.options.verbose
  
+        if self.options.disableProxyCheck:
+            self.disableProxyCheck = self.options.disableProxyCheck
+
         if self.options.proxy:
             os.environ["X509_USER_PROXY"] = self.options.proxy
 
@@ -259,6 +270,9 @@ class Client(object):
 
     #Check whether the proxy exists and if it has any time left. 
     def checkProxy(self):
+        if self.disableProxyCheck:
+            return        
+
         if not os.environ.has_key("X509_USER_PROXY"):
             raise Exception("X509_USER_PROXY not set")
     


### PR DESCRIPTION
In large environments with multiple CREAM tests per service invoking Java-based voms-proxy-info for each service/test creates significant load. ARGO has internal check of proxy validity and in case proxy expires data is excluded from A/R calculation.